### PR TITLE
Add `square-root`icon

### DIFF
--- a/icons/square-root-square.json
+++ b/icons/square-root-square.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "smnandre"
+  ],
+  "tags": [
+    "calculate",
+    "formula",
+    "maths",
+    "operator",
+    "root",
+    "square",
+    "symbol"
+  ],
+  "categories": [
+    "development",
+    "maths",
+    "shapes"
+  ]
+}

--- a/icons/square-root-square.svg
+++ b/icons/square-root-square.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M19 3H5a2 2 0 0 0-2 2v14c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Z"/>
+  <path d="M7 12h2l2 5 2-10h4"/>
+</svg>

--- a/icons/square-root.json
+++ b/icons/square-root.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "smnandre"
+  ],
+  "tags": [
+    "calculate",
+    "formula",
+    "maths",
+    "operator",
+    "root",
+    "square",
+    "symbol"
+  ],
+  "categories": [
+    "development",
+    "maths"
+  ]
+}

--- a/icons/square-root.svg
+++ b/icons/square-root.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 12h4l4 10 4-20h8" />
+</svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] New Icon 
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description

Add a "square root" icon, in two formats like the other math operators

### Icon use case 

* Buttons for calculator
* Section/tags for sorting math lessons

## Icon Design Checklist

### Concept 
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: activity, percent-square
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to two points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
